### PR TITLE
Add sound_decoupler_fire FX to several parts.

### DIFF
--- a/GameData/HGR/Parts/Utility/EscapeTower/SmallEscapeTowerHGR.cfg
+++ b/GameData/HGR/Parts/Utility/EscapeTower/SmallEscapeTowerHGR.cfg
@@ -25,6 +25,7 @@ PART
 	sound_vent_medium = engage
 	sound_rocket_hard = running
 	sound_vent_soft = disengage
+	sound_decoupler_fire = decouple
 
 // --- editor parameters ---
 	TechRequired = survivability

--- a/GameData/HGR/Parts/Utility/Heavy Escape Tower/HeavyLES.cfg
+++ b/GameData/HGR/Parts/Utility/Heavy Escape Tower/HeavyLES.cfg
@@ -20,6 +20,7 @@ PART
 	sound_rocket_hard = running
 	sound_vent_soft = disengage
 	sound_explosion_low = flameout
+	sound_decoupler_fire = decouple
 
 // --- editor parameters ---
 	TechRequired = landing

--- a/GameData/HGR/Parts/Utility/InLineChute/InLineChute.cfg
+++ b/GameData/HGR/Parts/Utility/InLineChute/InLineChute.cfg
@@ -18,7 +18,7 @@ PART
 
 // --- FX definitions ---
 	sound_parachute_open = activate
-
+	sound_decoupler_fire = decouple
 
 // --- editor parameters ---
 	TechRequired = landing

--- a/GameData/HGR/Parts/Utility/SmallInlineChute/InLineChuteSmall.cfg
+++ b/GameData/HGR/Parts/Utility/SmallInlineChute/InLineChuteSmall.cfg
@@ -18,7 +18,7 @@ PART
 
 // --- FX definitions ---
 	sound_parachute_open = activate
-
+	sound_decoupler_fire = decouple
 
 // --- editor parameters ---
 	TechRequired = survivability


### PR DESCRIPTION
This fixes the log file error "Cannot find fx group of that name for decoupler".