### PR TITLE
Fix SoyJuice decoupler offsets to make cables match connectors.

### DIFF
--- a/GameData/HGR/Parts/Utility/SoyJuice Decoupler/SoyDecoupler.cfg
+++ b/GameData/HGR/Parts/Utility/SoyJuice Decoupler/SoyDecoupler.cfg
@@ -12,8 +12,8 @@ PART
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-	node_stack_bottom = 0.0, -0.149, 0.0, 0.0, -1.0, 0.0, 1
-	node_stack_top = 0.0, -0.02, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -0.148, 0.0, 0.0, -1.0, 0.0, 2
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
 
 	// --- FX definitions ---
 

--- a/GameData/HGR/Parts/Utility/SoyJuice Decoupler/SoyDecoupler.cfg
+++ b/GameData/HGR/Parts/Utility/SoyJuice Decoupler/SoyDecoupler.cfg
@@ -12,8 +12,9 @@ PART
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-	node_stack_bottom = 0.0, -0.148, 0.0, 0.0, -1.0, 0.0, 2
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.149, 0.0, 0.0, -1.0, 0.0, 2
+	// The negative offset allows for proper alignment when a heat shield is mounted on the SoyJuice capsule.
+	node_stack_top = 0.0, -0.01, 0.0, 0.0, 1.0, 0.0, 2
 
 	// --- FX definitions ---
 


### PR DESCRIPTION
Adjust node offsets so that the cables match the holes in the SoyJuice pods.

Also change node size to match the other HGR parts.