### PR TITLE
Add a title to the agency configuration get rid of load-time warning.

### DIFF
--- a/GameData/HGR/Agencies/Agents.cfg
+++ b/GameData/HGR/Agencies/Agents.cfg
@@ -28,7 +28,7 @@
 AGENT
 {
   name = Home Grown Rocket Parts
-  
+  title = NA
   description = NA
   
   logoURL = HGR/Agencies/HGR


### PR DESCRIPTION
There's a load-time warning about a missing title field in the agency configuration.

Not actually sure where that gets used in the game, but this fixes the warning.