### PR TITLE
Correct action names for deploying/retracting the antenna on solar panels

### DIFF
--- a/GameData/HGR/Parts/Utility/SoySolarPanels/HGRSolarPanels1.cfg
+++ b/GameData/HGR/Parts/Utility/SoySolarPanels/HGRSolarPanels1.cfg
@@ -64,6 +64,9 @@ PART
 	{
 		name = ModuleDeployableAntenna
 		animationName = Antenna
+		extendActionName = #autoLOC_6002398 //#autoLOC_6002398 = Extend <<1>>
+		retractActionName = #autoLOC_6002399 //#autoLOC_6002399 = Retract <<1>>
+		extendpanelsActionName = #autoLOC_6002400 //#autoLOC_6002400 = Toggle <<1>>
 
 		pivotName = pCylinder9
 		showStatus = false

--- a/GameData/HGR/Parts/Utility/SoySolarPanels/HGRSolarPanels1.cfg
+++ b/GameData/HGR/Parts/Utility/SoySolarPanels/HGRSolarPanels1.cfg
@@ -66,7 +66,6 @@ PART
 		animationName = Antenna
 		extendActionName = #autoLOC_6002398 //#autoLOC_6002398 = Extend <<1>>
 		retractActionName = #autoLOC_6002399 //#autoLOC_6002399 = Retract <<1>>
-		extendpanelsActionName = #autoLOC_6002400 //#autoLOC_6002400 = Toggle <<1>>
 
 		pivotName = pCylinder9
 		showStatus = false


### PR DESCRIPTION
This is to make the action names for the antennae distinct from the panels.  The localised text reference is to the KSP localisation database and was taken from the Communotron 16.

Even better would be to make the antenna their own part meaning they could also be used with other solar panels, but that would of course take a lot more work.